### PR TITLE
Remove `EnvironmentId` fields

### DIFF
--- a/src/WorkOS.net/Services/AuditTrail/Entities/EventAction.cs
+++ b/src/WorkOS.net/Services/AuditTrail/Entities/EventAction.cs
@@ -24,11 +24,5 @@
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// The identifier of the Event Action's Environment.
-        /// </summary>
-        [JsonProperty("environment_id")]
-        public string EnvironmentId { get; set; }
     }
 }

--- a/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
@@ -55,12 +55,6 @@
         public string OrganizationId { get; set; }
 
         /// <summary>
-        /// Identifier for the Directory's Environment.
-        /// </summary>
-        [JsonProperty("environment_id")]
-        public string EnvironmentId { get; set; }
-
-        /// <summary>
         /// The timestamp of when the Directory was created.
         /// </summary>
         [JsonProperty("created_at")]

--- a/src/WorkOS.net/Services/MFA/Entities/Factor.cs
+++ b/src/WorkOS.net/Services/MFA/Entities/Factor.cs
@@ -39,12 +39,6 @@ namespace WorkOS
         public string Type { get; set; }
 
         /// <summary>
-        /// The unique identifier for the Organization in which the MFA Factor resides.
-        /// </summary>
-        [JsonProperty("environment_id")]
-        public string EnvironmentId { get; set; }
-
-        /// <summary>
         /// Totp details when enroll response is Totp.
         /// </summary>
         [JsonProperty("totp")]

--- a/test/WorkOSTests/Services/AuditTrail/AuditTrailSeviceTest.cs
+++ b/test/WorkOSTests/Services/AuditTrail/AuditTrailSeviceTest.cs
@@ -62,7 +62,6 @@
                         {
                             Id = "event_action_id",
                             Name = "user.updated_directory",
-                            EnvironmentId = "environment_id",
                         },
                         ActorId = "user_id",
                         ActorName = "demo@foo-corp.com",

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -59,7 +59,6 @@
                 State = DirectoryState.Linked,
                 Type = DirectoryType.BambooHR,
                 ExternalKey = "external-key",
-                EnvironmentId = "environment_123",
                 OrganizationId = "organization_123",
                 CreatedAt = "2021-07-26T18:55:16.072Z",
                 UpdatedAt = "2021-07-26T18:55:16.072Z",

--- a/test/WorkOSTests/Services/MFA/MFAServiceTest.cs
+++ b/test/WorkOSTests/Services/MFA/MFAServiceTest.cs
@@ -33,7 +33,6 @@ namespace WorkOSTests
                 CreatedAt = "2022-02-17T22:39:26.616Z",
                 UpdatedAt = "2022-02-17T22:39:26.616Z",
                 Type = "generic_otp",
-                EnvironmentId = "environment_test123",
             };
 
             this.httpMock.MockResponse(
@@ -62,7 +61,6 @@ namespace WorkOSTests
                 CreatedAt = "2022-02-17T22:39:26.616Z",
                 UpdatedAt = "2022-02-17T22:39:26.616Z",
                 Type = "sms",
-                EnvironmentId = "environment_test123",
                 Sms = phoneDetails,
             };
 
@@ -95,7 +93,6 @@ namespace WorkOSTests
                 CreatedAt = "2022-02-17T22:39:26.616Z",
                 UpdatedAt = "2022-02-17T22:39:26.616Z",
                 Type = "sms",
-                EnvironmentId = "environment_test123",
                 Totp = totpDetails,
             };
 
@@ -216,7 +213,6 @@ namespace WorkOSTests
                 CreatedAt = "2022-02-17T22:39:26.616Z",
                 UpdatedAt = "2022-02-17T22:39:26.616Z",
                 Type = "generic_otp",
-                EnvironmentId = "environment_test123",
             };
 
             this.httpMock.MockResponse(
@@ -244,7 +240,6 @@ namespace WorkOSTests
                 CreatedAt = "2022-02-17T22:39:26.616Z",
                 UpdatedAt = "2022-02-17T22:39:26.616Z",
                 Type = "generic_otp",
-                EnvironmentId = "environment_test123",
             };
 
             this.httpMock.MockResponse(


### PR DESCRIPTION
This PR removes the `EnvironmentId` fields from various objects, as these fields are not returned by the API.

Resolves SDK-428.