### PR TITLE
Remove connection as return value from Delete Connection

### DIFF
--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -137,8 +137,8 @@
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A deleted WorkOS Connection record.</returns>
-        public async Task<Connection> DeleteConnection(string id, CancellationToken cancellationToken = default)
+        /// <returns>A Task.</returns>
+        public async Task DeleteConnection(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -146,7 +146,7 @@
                 Path = $"/connections/{id}",
             };
 
-            return await this.Client.MakeAPIRequest<Connection>(request, cancellationToken);
+            await this.Client.MakeRawAPIRequest(request, cancellationToken);
         }
     }
 }

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -321,5 +321,21 @@
                 JsonConvert.SerializeObject(this.mockConnection),
                 JsonConvert.SerializeObject(response));
         }
+
+        [Fact]
+        public async void TestDeleteConnection()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockConnection));
+
+            await this.service.DeleteConnection(this.mockConnection.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}");
+        }
     }
 }

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -328,8 +328,8 @@
             this.httpMock.MockResponse(
                 HttpMethod.Delete,
                 $"/connections/{this.mockConnection.Id}",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockConnection));
+                HttpStatusCode.NoContent,
+                "Resource deleted successfully");
 
             await this.service.DeleteConnection(this.mockConnection.Id);
 


### PR DESCRIPTION
DeleteConnection method shouldn't return Connection. Removed Connection as return value and now returns Task.