### PR TITLE
v1.17.1

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "1.17.0";
+        public static string SdkVersion => "1.17.1";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.17.0</VersionPrefix>
-    <Version>1.17.0</Version>
+    <VersionPrefix>1.17.1</VersionPrefix>
+    <Version>1.17.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Version bump for fix to add int and long to FlattenQueryParam method. (https://github.com/workos/workos-dotnet/pull/119/files)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
