### PR TITLE
Change BaseOptions to ListOptions in ListOrganizationsOptions

### DIFF
--- a/src/WorkOS.net/Services/Organizations/_interfaces/ListOrganizationsOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/ListOrganizationsOptions.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// The parameters to fetch Organizations.
     /// </summary>
-    public class ListOrganizationsOptions : BaseOptions
+    public class ListOrganizationsOptions : ListOptions
     {
         /// <summary>
         /// Domains of an <see cref="Organization"/>. Can be empty.


### PR DESCRIPTION
## Description

ListOrganizationsOptions wasn't inheriting from ListOptions, which prevented parameters like Limit, Before, and After from being used. I'm new to .NET, so I could be wrong, but I tested this, and this change fixes the errors I was getting.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

These parameters are already in the docs so no change is required.

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
