### PR TITLE
Fix user enums to include "Inactive"

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
@@ -13,7 +13,7 @@
         [EnumMember(Value = "active")]
         Active,
         
-         [EnumMember(Value = "inactive")]
+        [EnumMember(Value = "inactive")]
         Inactive,
         
         [EnumMember(Value = "suspended")]

--- a/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
@@ -12,10 +12,8 @@
     {
         [EnumMember(Value = "active")]
         Active,
-        
         [EnumMember(Value = "inactive")]
         Inactive,
-        
         [EnumMember(Value = "suspended")]
         Suspended,
     }

--- a/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/UserState.cs
@@ -12,7 +12,10 @@
     {
         [EnumMember(Value = "active")]
         Active,
-
+        
+         [EnumMember(Value = "inactive")]
+        Inactive,
+        
         [EnumMember(Value = "suspended")]
         Suspended,
     }


### PR DESCRIPTION
## Description

Adds inactive as a user state.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
