### PR TITLE
Add `created_at` field to webhook entity

### DIFF
--- a/src/WorkOS.net/Services/Webhooks/Entities/Webhook.cs
+++ b/src/WorkOS.net/Services/Webhooks/Entities/Webhook.cs
@@ -24,5 +24,11 @@ namespace WorkOS
         /// </summary>
         [JsonProperty("data")]
         public object Data { get; set; }
+
+        /// <summary>
+        /// The created_at timestamp of the event.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
     }
 }

--- a/src/WorkOS.net/Services/Webhooks/Entities/Webhook.cs
+++ b/src/WorkOS.net/Services/Webhooks/Entities/Webhook.cs
@@ -26,7 +26,7 @@ namespace WorkOS
         public object Data { get; set; }
 
         /// <summary>
-        /// The created_at timestamp of the event.
+        /// The timestamp of when the event was created.
         /// </summary>
         [JsonProperty("created_at")]
         public string CreatedAt { get; set; }


### PR DESCRIPTION
## Description
We've recently added a new `created_at` field to webhook request payload, 
This PR updates the SDK where needed

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
