### PR TITLE
Add `ActorIds` and `ActorNames` to `CreateAuditLogExportOptions`

### DIFF
--- a/src/WorkOS.net/Services/AuditLogs/_interfaces/CreateAuditLogExportOptions.cs
+++ b/src/WorkOS.net/Services/AuditLogs/_interfaces/CreateAuditLogExportOptions.cs
@@ -40,7 +40,20 @@ namespace WorkOS
         /// Actor names that Audit Log Events will be filtered by.
         /// </summary>
         [JsonProperty("actors")]
+        [Obsolete("Please use ActorNames instead.")]
         public List<string> Actors { get; set; }
+
+        /// <summary>
+        /// Actor names that Audit Log Events will be filtered by.
+        /// </summary>
+        [JsonProperty("actor_names")]
+        public List<string> ActorNames { get; set; }
+
+        /// <summary>
+        /// Actor IDs that Audit Log Events will be filtered by.
+        /// </summary>
+        [JsonProperty("actor_ids")]
+        public List<string> ActorIds { get; set; }
 
         /// <summary>
         /// Target types that Audit Log Events will be filtered by.

--- a/test/WorkOSTests/Services/AuditLogs/AuditLogsSeviceTest.cs
+++ b/test/WorkOSTests/Services/AuditLogs/AuditLogsSeviceTest.cs
@@ -117,7 +117,9 @@
                 RangeEnd = DateTime.Now,
                 Actions = new List<string>()
                 { "user.signed_in" },
+#pragma warning disable CS0618 // CreateAuditLogExportOptions.Actors' is obsolete: 'Please use ActorNames instead.
                 Actors = new List<string>()
+#pragma warning restore CS0618 // CreateAuditLogExportOptions.Actors' is obsolete: 'Please use ActorNames instead.
                 { "Actor" },
                 ActorNames = new List<string>()
                 { "Actor" },

--- a/test/WorkOSTests/Services/AuditLogs/AuditLogsSeviceTest.cs
+++ b/test/WorkOSTests/Services/AuditLogs/AuditLogsSeviceTest.cs
@@ -119,6 +119,10 @@
                 { "user.signed_in" },
                 Actors = new List<string>()
                 { "Actor" },
+                ActorNames = new List<string>()
+                { "Actor" },
+                ActorIds = new List<string>()
+                { "user_foo" },
                 Targets = new List<string>()
                 { "user" },
             };


### PR DESCRIPTION
## Description

- Adds `ActorIds` filter to `CreateAuditLogExportOptions`
- Adds `ActorNames` filter to `CreateAuditLogExportOptions`
- Deprecates `Actors` filter on `CreateAuditLogExportOptions`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
