### PR TITLE
Add Validating enum to ConnectionState

### DIFF
--- a/src/WorkOS.net/Services/SSO/Enums/ConnectionState.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ConnectionState.cs
@@ -19,5 +19,8 @@ namespace WorkOS
 
         [EnumMember(Value = "inactive")]
         Inactive,
+
+        [EnumMember(Value = "validating")]
+        Validating,
     }
 }


### PR DESCRIPTION
## Description
Add Validating enum to ConnectionState

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
