### PR TITLE
Add CreatedAt and UpdatedAt to directory user

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Entities/User.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/User.cs
@@ -82,6 +82,18 @@
         public UserState State { get; set; }
 
         /// <summary>
+        /// The timestamp of when the Directory User was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Directory User was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
+
+        /// <summary>
         /// The User's raw attributes.
         /// </summary>
         [JsonProperty("raw_attributes")]

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -73,6 +73,8 @@
                 LastName = "Sanchez",
                 JobTitle = "Software Engineer",
                 Username = "rick.sanchez",
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
                 State = UserState.Active,
                 CustomAttributes = new Dictionary<string, object>()
                 {


### PR DESCRIPTION
## Description
Add CreatedAt and UpdatedAt to directory user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
