### PR TITLE
Add `CreatePasswordResetChallenge` and `CompletePasswordReset`

### DIFF
--- a/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
+++ b/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
@@ -139,5 +139,43 @@ namespace WorkOS
             };
             return await this.Client.MakeAPIRequest<(User, Session)>(request, cancellationToken);
         }
+
+        /// <summary>
+        /// Create a Password Reset challenge.
+        /// </summary>
+        /// <param name="options"> Parameters used to create a password reset challenge.</param>
+        /// <param name="cancellationToken">An optional token to cancel the request.</param>
+        /// <returns> The token string and corresponding User object.</returns>
+        public async Task<(string, User)> CreatePasswordResetChallenge(
+            CreatePasswordResetChallengeOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                Options = options,
+                Method = HttpMethod.Post,
+                Path = $"/users/password_reset_challenge",
+            };
+            return await this.Client.MakeAPIRequest<(string, User)>(request, cancellationToken);
+        }
+
+        /// <summary>
+        /// Complete a Password Reset.
+        /// </summary>
+        /// <param name="options"> Parameters used to complete a password reset.</param>
+        /// <param name="cancellationToken">An optional token to cancel the request.</param>
+        /// <returns> The corresponding User object.</returns>
+        public async Task<User> CompletePasswordReset(
+            CompletePasswordResetOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                Options = options,
+                Method = HttpMethod.Post,
+                Path = $"/users/password_reset",
+            };
+            return await this.Client.MakeAPIRequest<User>(request, cancellationToken);
+        }
     }
 }

--- a/src/WorkOS.net/Services/UserManagement/_interfaces/CompletePasswordResetOptions.cs
+++ b/src/WorkOS.net/Services/UserManagement/_interfaces/CompletePasswordResetOptions.cs
@@ -1,0 +1,22 @@
+namespace WorkOS
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The parameters to complete a password reset challenge.
+    /// </summary>
+    public class CompletePasswordResetOptions : ListOptions
+    {
+        /// <summary>
+        /// The reset token emailed to the user.
+        /// </summary>
+        [JsonProperty("token")]
+        public string Token { get; set; }
+
+        /// <summary>
+        /// The new password to be set for the user.
+        /// </summary>
+        [JsonProperty("new_password")]
+        public string NewPassword { get; set; }
+    }
+}

--- a/src/WorkOS.net/Services/UserManagement/_interfaces/CreatePasswordResetChallengeOptions.cs
+++ b/src/WorkOS.net/Services/UserManagement/_interfaces/CreatePasswordResetChallengeOptions.cs
@@ -1,0 +1,22 @@
+namespace WorkOS
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The parameters to create a password reset challenge.
+    /// </summary>
+    public class CreatePasswordResetChallengeOptions : ListOptions
+    {
+        /// <summary>
+        /// The email of the user that wishes to reset their password.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// The URL that will be linked to in the email.
+        /// </summary>
+        [JsonProperty("password_reset_url")]
+        public string PasswordResetUrl { get; set; }
+    }
+}

--- a/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
+++ b/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
@@ -31,6 +31,8 @@ namespace WorkOSTests
 
         private readonly Reason mockReasons;
 
+        private readonly string mockToken;
+
         private readonly CreateUserOptions mockCreateUserOptions;
 
         private readonly AuthenticateUserWithPasswordOptions mockAuthenticateUserWithPasswordOptions;
@@ -38,6 +40,10 @@ namespace WorkOSTests
         private readonly AuthenticateUserWithCodeOptions mockAuthenticateUserWithCodeOptions;
 
         private readonly AuthenticateUserWithMagicAuthOptions mockAuthenticateUserWithMagicAuthOptions;
+
+        private readonly CreatePasswordResetChallengeOptions mockCreatePasswordResetChallengeOptions;
+
+        private readonly CompletePasswordResetOptions mockCompletePasswordResetOptions;
 
         public UserManagementServiceTest()
         {
@@ -154,6 +160,8 @@ namespace WorkOSTests
                     },
             };
 
+            this.mockToken = "token_1234";
+
             this.mockCreateUserOptions = new CreateUserOptions
             {
                 Email = "marcelina.davis@gmail.com",
@@ -184,6 +192,18 @@ namespace WorkOSTests
                 ClientSecret = "client_secret_123",
                 Code = "code_123",
                 MagicAuthChallengeId = "auth_challenge_123",
+            };
+
+            this.mockCreatePasswordResetChallengeOptions = new CreatePasswordResetChallengeOptions
+            {
+                Email = "marcelina.davis@gmail.com",
+                PasswordResetUrl = "password_1234",
+            };
+
+            this.mockCompletePasswordResetOptions = new CompletePasswordResetOptions
+            {
+                Token = "token_1234",
+                NewPassword = "new_password_1234",
             };
         }
 
@@ -312,6 +332,44 @@ namespace WorkOSTests
             Assert.Equal(
                 JsonConvert.SerializeObject(session),
                 JsonConvert.SerializeObject(this.mockSession));
+        }
+
+        [Fact]
+        public async void TestCreatePasswordResetChallenge()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Post,
+                $"/users/password_reset_challenge",
+                HttpStatusCode.Created,
+                RequestUtilities.ToJsonString((this.mockToken, this.mockUser)));
+
+            var (token, user) = await this.service.CreatePasswordResetChallenge(this.mockCreatePasswordResetChallengeOptions);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Post,
+                $"/users/password_reset_challenge");
+            Assert.Equal(
+                JsonConvert.SerializeObject(token),
+                JsonConvert.SerializeObject(this.mockToken));
+        }
+
+        [Fact]
+        public async void TestCompletePasswordReset()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Post,
+                $"/users/password_reset",
+                HttpStatusCode.Created,
+                RequestUtilities.ToJsonString(this.mockUser));
+
+            var user = await this.service.CompletePasswordReset(this.mockCompletePasswordResetOptions);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Post,
+                $"/users/password_reset");
+            Assert.Equal(
+                JsonConvert.SerializeObject(user),
+                JsonConvert.SerializeObject(this.mockUser));
         }
     }
 }


### PR DESCRIPTION
## Description
Add `CreatePasswordResetChallenge`
Add `CompletePasswordReset`
* Fixes USRLD-752, USRLD-753

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
