### PR TITLE
Add `VerifyEmailResponse`

### DIFF
--- a/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
+++ b/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
@@ -182,8 +182,8 @@ namespace WorkOS
         /// </summary>
         /// <param name="options"> Parameters used to complete email verification.</param>
         /// <param name="cancellationToken">An optional token to cancel the request.</param>
-        /// <returns> The corresponding User object.</returns>
-        public async Task<User> VerifyEmail(
+        /// <returns> The corresponding VerifyEmailResponse object.</returns>
+        public async Task<VerifyEmailResponse> VerifyEmail(
             VerifyEmailOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -193,7 +193,7 @@ namespace WorkOS
                 Method = HttpMethod.Post,
                 Path = $"/users/{options.UserId}/verify_email",
             };
-            return await this.Client.MakeAPIRequest<User>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<VerifyEmailResponse>(request, cancellationToken);
         }
 
         /// <summary>

--- a/src/WorkOS.net/Services/UserManagement/_interfaces/VerifyEmailResponse.cs
+++ b/src/WorkOS.net/Services/UserManagement/_interfaces/VerifyEmailResponse.cs
@@ -1,0 +1,18 @@
+namespace WorkOS
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents a response for a Verify Email.
+    /// </summary>
+    public class VerifyEmailResponse
+    {
+        /// <summary>
+        /// The corresponding User object.
+        /// </summary>
+        [JsonProperty("user")]
+        public User User { get; set; }
+    }
+}

--- a/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
+++ b/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
@@ -38,6 +38,8 @@ namespace WorkOSTests
         private readonly SendVerificationEmailResponse mockSendVerificationEmailResponse;
         private readonly AuthenticateUserResponse mockAuthenticateUserResponse;
 
+        private readonly VerifyEmailResponse mockVerifyEmailResponse;
+
         private readonly CreateUserOptions mockCreateUserOptions;
 
         private readonly AuthenticateUserWithPasswordOptions mockAuthenticateUserWithPasswordOptions;
@@ -179,6 +181,11 @@ namespace WorkOSTests
             };
 
             this.mockAuthenticateUserResponse = new AuthenticateUserResponse
+            {
+                User = this.mockUser,
+            };
+
+            this.mockVerifyEmailResponse = new VerifyEmailResponse
             {
                 User = this.mockUser,
             };
@@ -433,14 +440,14 @@ namespace WorkOSTests
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockUser));
 
-            var user = await this.service.VerifyEmail(this.mockVerifyEmailOptions);
+            var response = await this.service.VerifyEmail(this.mockVerifyEmailOptions);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Post,
                 $"/users/{this.mockUser.Id}/verify_email");
             Assert.Equal(
-                JsonConvert.SerializeObject(user),
-                JsonConvert.SerializeObject(this.mockUser));
+                JsonConvert.SerializeObject(response),
+                JsonConvert.SerializeObject(this.mockVerifyEmailResponse));
         }
 
         [Fact]

--- a/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
+++ b/test/WorkOSTests/Services/UserManagement/UserManagementServiceTest.cs
@@ -438,7 +438,7 @@ namespace WorkOSTests
                 HttpMethod.Post,
                 $"/users/{this.mockUser.Id}/verify_email",
                 HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(this.mockUser));
+                RequestUtilities.ToJsonString(this.mockVerifyEmailResponse));
 
             var response = await this.service.VerifyEmail(this.mockVerifyEmailOptions);
 


### PR DESCRIPTION
## Description
Add `VerifyEmailResponse` to replace return `User` in `VerifyEmail`
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
