### PR TITLE
Change default list pagination order to be DESC

### DIFF
--- a/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
+++ b/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
@@ -29,6 +29,6 @@
         /// The order in which to paginate records.
         /// </summary>
         [JsonProperty("order")]
-        public PaginationOrder? Order { get; set; }
+        public PaginationOrder Order { get; set; } = PaginationOrder.Desc;
     }
 }


### PR DESCRIPTION
## Description

This was updated in #136 but reverted in #158; this PR adds it back since we are going for a major version release and this is a backward breaking change.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
