### PR TITLE
Deploy to NuGet when a Release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  # Support manually pushing a new release
+  workflow_dispatch: {}
+  # Trigger when a release is published
+  release:
+    types: [released]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Publish to NuGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dotNet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            3.1.x
+
+      - name: Publish
+        env:
+          DOTNET_NUGET_API_KEY: ${{ secrets.DOTNET_NUGET_API_KEY }}
+        run: |
+          dotnet pack -c Release src/WorkOS.net/WorkOS.net.csproj
+          dotnet nuget push src/WorkOS.net/bin/Release/WorkOS.net.*.nupkg -s https://api.nuget.org/v3/index.json --skip-duplicate -k $DOTNET_NUGET_API_KEY


### PR DESCRIPTION
## Description
We are updating our SDK release processes to be automatic via GitHub Actions.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
