### PR TITLE
Add `DomainData` to Organization create and update methods, replacing deprecated `domains`

### DIFF
--- a/src/WorkOS.net/Services/MFA/Entities/Totp.cs
+++ b/src/WorkOS.net/Services/MFA/Entities/Totp.cs
@@ -8,7 +8,7 @@ namespace WorkOS
     /// </summary>
     public class Totp
     {
-         /// <summary>
+        /// <summary>
         /// Issuer of the factor.
         /// </summary>
         [JsonProperty("issuer")]

--- a/src/WorkOS.net/Services/MFA/_interfaces/ChallengeFactorOptions.cs
+++ b/src/WorkOS.net/Services/MFA/_interfaces/ChallengeFactorOptions.cs
@@ -1,4 +1,4 @@
- namespace WorkOS
+namespace WorkOS
 {
     using Newtonsoft.Json;
 

--- a/src/WorkOS.net/Services/MFA/_interfaces/VerifyChallengeOptions.cs
+++ b/src/WorkOS.net/Services/MFA/_interfaces/VerifyChallengeOptions.cs
@@ -1,4 +1,4 @@
- namespace WorkOS
+namespace WorkOS
 {
     using Newtonsoft.Json;
 

--- a/src/WorkOS.net/Services/MFA/_interfaces/VerifyFactorOptions.cs
+++ b/src/WorkOS.net/Services/MFA/_interfaces/VerifyFactorOptions.cs
@@ -1,4 +1,4 @@
- namespace WorkOS
+namespace WorkOS
 {
     using System;
     using Newtonsoft.Json;

--- a/src/WorkOS.net/Services/Organizations/Enums/OrganizationDomainDataState.cs
+++ b/src/WorkOS.net/Services/Organizations/Enums/OrganizationDomainDataState.cs
@@ -1,0 +1,19 @@
+namespace WorkOS
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// An enum describing the state of an Organization Domain.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum OrganizationDomainDataState
+    {
+        [EnumMember(Value = "verified")]
+        Verified,
+
+        [EnumMember(Value = "pending")]
+        Pending,
+    }
+}

--- a/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace WorkOS
 {
+    using System;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -21,8 +22,15 @@
         public bool? AllowProfilesOutsideOrganization { get; set; }
 
         /// <summary>
+        /// Data for setting the domains of the <see cref="Organization"/>.
+        /// </summary>
+        [JsonProperty("domain_data")]
+        public OrganizationDomainDataOptions[] DomainData { get; set; }
+
+        /// <summary>
         /// Domains of the <see cref="Organization"/>.
         /// </summary>
+        [ObsoleteAttribute("Use DomainData instead.", false)]
         [JsonProperty("domains")]
         public string[] Domains { get; set; }
     }

--- a/src/WorkOS.net/Services/Organizations/_interfaces/OrganizationDomainDataOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/OrganizationDomainDataOptions.cs
@@ -1,0 +1,22 @@
+namespace WorkOS
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The parameters to configure a Domain as part of an Organization.
+    /// </summary>
+    public class OrganizationDomainDataOptions : BaseOptions
+    {
+        /// <summary>
+        /// Domain of the <see cref="Organization"/>.
+        /// </summary>
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// State of the <see cref="OrganizationDomainDataOptions"/>.
+        /// </summary>
+        [JsonProperty("state")]
+        public OrganizationDomainDataState State { get; set; }
+    }
+}

--- a/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
@@ -1,5 +1,6 @@
 namespace WorkOS
 {
+    using System;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -27,8 +28,15 @@ namespace WorkOS
         public bool? AllowProfilesOutsideOrganization { get; set; }
 
         /// <summary>
+        /// Data for setting the domains of the <see cref="Organization"/>.
+        /// </summary>
+        [JsonProperty("domain_data")]
+        public OrganizationDomainDataOptions[] DomainData { get; set; }
+
+        /// <summary>
         /// Domains of the <see cref="Organization"/>.
         /// </summary>
+        [ObsoleteAttribute("Use DomainData instead.", false)]
         [JsonProperty("domains")]
         public string[] Domains { get; set; }
     }

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -36,28 +36,34 @@ namespace WorkOSTests
             this.createOrganizationOptions = new CreateOrganizationOptions
             {
                 Name = "Foo Corp",
+#pragma warning disable 618
                 Domains = new string[]
                 {
                     "foo-corp.com",
                 },
+#pragma warning restore 618
             };
 
             this.updateOrganizationOptions = new UpdateOrganizationOptions
             {
                 Organization = "org_123",
+#pragma warning disable 618
                 Domains = new string[]
                 {
                     "foo-corp.com",
                 },
+#pragma warning restore 618
                 Name = "Foo Corp 2",
             };
 
             this.listOrganizationsOptions = new ListOrganizationsOptions
             {
+#pragma warning disable 618
                 Domains = new string[]
                 {
                     "foo-corp.com",
                 },
+#pragma warning restore 618
             };
 
             this.mockOrganization = new Organization

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -36,34 +36,36 @@ namespace WorkOSTests
             this.createOrganizationOptions = new CreateOrganizationOptions
             {
                 Name = "Foo Corp",
-#pragma warning disable 618
-                Domains = new string[]
+                DomainData = new OrganizationDomainDataOptions[]
                 {
-                    "foo-corp.com",
+                    new OrganizationDomainDataOptions
+                    {
+                        Domain = "foo-corp.com",
+                        State = OrganizationDomainDataState.Pending,
+                    },
                 },
-#pragma warning restore 618
             };
 
             this.updateOrganizationOptions = new UpdateOrganizationOptions
             {
                 Organization = "org_123",
-#pragma warning disable 618
-                Domains = new string[]
+                DomainData = new OrganizationDomainDataOptions[]
                 {
-                    "foo-corp.com",
+                    new OrganizationDomainDataOptions
+                    {
+                        Domain = "foo-corp.com",
+                        State = OrganizationDomainDataState.Verified,
+                    },
                 },
-#pragma warning restore 618
                 Name = "Foo Corp 2",
             };
 
             this.listOrganizationsOptions = new ListOrganizationsOptions
             {
-#pragma warning disable 618
                 Domains = new string[]
                 {
                     "foo-corp.com",
                 },
-#pragma warning restore 618
             };
 
             this.mockOrganization = new Organization
@@ -116,6 +118,33 @@ namespace WorkOSTests
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockOrganization));
             var response = await this.service.CreateOrganization(this.createOrganizationOptions);
+
+            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/organizations");
+            Assert.Equal(
+                JsonConvert.SerializeObject(this.mockOrganization),
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
+        public async void TestCreateOrganizationWithObsoleteDomains()
+        {
+            var createOrganizationOptions = new CreateOrganizationOptions
+            {
+                Name = "Foo Corp",
+#pragma warning disable CS0618 // `Domains` is obsolete
+                Domains = new string[]
+                {
+                    "foo-corp.com",
+                },
+            };
+#pragma warning restore CS0618
+
+            this.httpMock.MockResponse(
+                HttpMethod.Post,
+                "/organizations",
+                HttpStatusCode.Created,
+                RequestUtilities.ToJsonString(this.mockOrganization));
+            var response = await this.service.CreateOrganization(createOrganizationOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/organizations");
             Assert.Equal(
@@ -185,6 +214,34 @@ namespace WorkOSTests
             var response = await this.service.UpdateOrganization(this.updateOrganizationOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Put, $"/organizations/{this.updateOrganizationOptions.Organization}");
+            Assert.Equal(
+                JsonConvert.SerializeObject(this.mockOrganization),
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
+        public async void TestUpdateOrganizationWithObsoleteDomains()
+        {
+            var updateOrganizationOptions = new UpdateOrganizationOptions
+            {
+                Organization = "org_123",
+                Name = "Foo Corp",
+#pragma warning disable CS0618 // `Domains` is obsolete
+                Domains = new string[]
+                {
+                    "foo-corp.com",
+                },
+            };
+#pragma warning restore CS0618
+
+            this.httpMock.MockResponse(
+                HttpMethod.Put,
+                $"/organizations/{this.updateOrganizationOptions.Organization}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockOrganization));
+            var response = await this.service.UpdateOrganization(updateOrganizationOptions);
+
+            this.httpMock.AssertRequestWasMade(HttpMethod.Put, $"/organizations/{updateOrganizationOptions.Organization}");
             Assert.Equal(
                 JsonConvert.SerializeObject(this.mockOrganization),
                 JsonConvert.SerializeObject(response));


### PR DESCRIPTION
## Description

Adds a new `DomainData` option to be passed to Organization create and update calls, instead of the `Domains` parameter which is being deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
