### PR TITLE
v2.1.0

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "2.0.0";
+        public static string SdkVersion => "2.1.0";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>2.0.3</VersionPrefix>
-    <Version>2.0.3</Version>
+    <VersionPrefix>2.1.0</VersionPrefix>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Bumps the version to `2.1.0`, releasing the changes from the following:

* #165 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
