### PR TITLE
Add AppleOAuth constants

### DIFF
--- a/src/WorkOS.net/Services/SSO/Entities/Connection.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Connection.cs
@@ -37,6 +37,7 @@
         /// One of:
         /// <c>ADFSSAML</c>
         /// <c>AdpOidc</c>
+        /// <c>AppleOAuth</c>
         /// <c>Auth0SAML</c>
         /// <c>AzureSAML</c>
         /// <c>CasSAML</c>

--- a/src/WorkOS.net/Services/SSO/Enums/ProviderType.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ProviderType.cs
@@ -10,6 +10,9 @@
     [JsonConverter(typeof(StringEnumConverter))]
     public enum ProviderType
     {
+        [EnumMember(Value = "AppleOAuth")]
+        AppleOAuth,
+
         [EnumMember(Value = "GitHubOAuth")]
         GitHubOAuth,
 


### PR DESCRIPTION
## Description
Add `AppleOAuth` constants so SDK users can kick off login flows with Sign in with Apple.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
