### PR TITLE
Mark `AllowProfilesOutsideOrganization` as deprecated

### DIFF
--- a/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
@@ -18,6 +18,7 @@
         /// Whether Connections within the Organization allow profiles that are
         /// outside of the Organization's configured User Email Domains.
         /// </summary>
+        [ObsoleteAttribute("If you need to allow sign-ins from any email domain, contact support@workos.com.", false)]
         [JsonProperty("allow_profiles_outside_organization")]
         public bool? AllowProfilesOutsideOrganization { get; set; }
 

--- a/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
@@ -24,6 +24,7 @@ namespace WorkOS
         /// Whether Connections within the Organization allow profiles that are
         /// outside of the Organization's configured User Email Domains.
         /// </summary>
+        [ObsoleteAttribute("If you need to allow sign-ins from any email domain, contact support@workos.com.", false)]
         [JsonProperty("allow_profiles_outside_organization")]
         public bool? AllowProfilesOutsideOrganization { get; set; }
 


### PR DESCRIPTION
## Description

Marks the `AllowProfilesOutsideOrganization` option to the create and update Organization SDK operations as deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
