### PR TITLE
Fix CI badge + add NuGet one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WorkOS .NET Library
 
-[![Build Status](https://workos.semaphoreci.com/badges/workos-dotnet/branches/main.svg?style=shields&key=343c1d18-79da-4ea3-89ce-8a6195a9d3d9)](https://workos.semaphoreci.com/projects/workos-dotnet)
+[![Packagist Version](https://img.shields.io/nuget/v/WorkOS.net)](https://www.nuget.org/packages/WorkOS.net)
+[![CI](https://github.com/workos/workos-dotnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/workos/workos-dotnet/actions/workflows/ci.yml)
 
 The WorkOS library for .NET provides convenient access to the WorkOS API from applications using .NET.
 Supports .NET Standard 2.0+ and .NET Framework 4.6.1+
@@ -84,7 +85,7 @@ can move to using the stable version.
 
 ## More Information
 
-* [Single Sign-On Guide](https://workos.com/docs/sso/guide)
-* [Directory Sync Guide](https://workos.com/docs/directory-sync/guide)
-* [Admin Portal Guide](https://workos.com/docs/admin-portal/guide)
-* [Magic Link Guide](https://workos.com/docs/magic-link/guide)
+- [Single Sign-On Guide](https://workos.com/docs/sso/guide)
+- [Directory Sync Guide](https://workos.com/docs/directory-sync/guide)
+- [Admin Portal Guide](https://workos.com/docs/admin-portal/guide)
+- [Magic Link Guide](https://workos.com/docs/magic-link/guide)


### PR DESCRIPTION
## Description
Replace the Semaphore badge with a Github Actions badge and add a NuGet badge to match our other repos.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
