### PR TITLE
Added missing values to DirectoryState enum

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryState.cs
@@ -13,10 +13,16 @@
         [EnumMember(Value = "linked")]
         Active,
 
+        [EnumMember(Value = "deleting")]
+        Deleting,
+
         [EnumMember(Value = "unlinked")]
         Inactive,
 
         [EnumMember(Value = "invalid_credentials")]
         InvalidCredentials,
+
+        [EnumMember(Value = "validating")]
+        Validating,
     }
 }


### PR DESCRIPTION
## Description
https://github.com/workos/workos-dotnet/issues/173 - Added missing values to DirectoryState enum. 

## Documentation
Documentation is missing some state values https://workos.com/docs/reference/directory-sync/directory (not sure how to raise a PR for this)
