### PR TITLE
Create webhook verification custom exceptions

### DIFF
--- a/src/WorkOS.net/Services/Webhooks/Exceptions/WorkOSWebhookException.cs
+++ b/src/WorkOS.net/Services/Webhooks/Exceptions/WorkOSWebhookException.cs
@@ -1,0 +1,12 @@
+﻿namespace WorkOS
+{
+    using System;
+
+    public class WorkOSWebhookException : Exception
+    {
+        public WorkOSWebhookException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/WorkOS.net/Services/Webhooks/WebhookService.cs
+++ b/src/WorkOS.net/Services/Webhooks/WebhookService.cs
@@ -55,7 +55,7 @@ namespace WorkOS
 
             if (!this.VerifyTimeTolerance(timeStamp, tolerance))
             {
-                throw new Exception("Timestamp outside of the tolerance zone");
+                throw new WorkOSWebhookException("Timestamp outside of the tolerance zone");
             }
 
             var signatureHash = timeAndSignature.Item2;
@@ -63,7 +63,7 @@ namespace WorkOS
 
             if (!this.SecureCompare(expectedSig, signatureHash))
             {
-                throw new Exception("Signature hash does not match the expected signature hash for payload");
+                throw new WorkOSWebhookException("Signature hash does not match the expected signature hash for payload");
             }
         }
 


### PR DESCRIPTION
## Description

When calling VerifyHeader it would be good to know the difference between verification exceptions and any other possible exception. Currently, generic Exceptions are thrown, if we change this to custom exceptions they can be caught and handled specifically.

After this change we can do:

```
 try
 {
    ...
    webhookService.VerifyHeader(body, header, secret, 300);
    ....
 }
 catch (WorkOSWebhookException ex)
 {
     // Handle webhook exception
 }
catch (Exception ex)
{
    // Other exception handling
}
```

This is a non-breaking change as the custom exception inherits Exception, so any existing consumer handling these will still catch them.

Fixes #176

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
