### PR TITLE
Add `role` to profile

### DIFF
--- a/src/WorkOS.net/Services/SSO/Entities/Profile.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Profile.cs
@@ -57,6 +57,12 @@
         public string LastName { get; set; }
 
         /// <summary>
+        /// The User's role.
+        /// </summary>
+        [JsonProperty("role")]
+        public RoleResponse? Role { get; set; }
+
+        /// <summary>
         /// The user's groups.
         /// </summary>
         [JsonProperty("groups")]

--- a/src/WorkOS.net/Services/SSO/Entities/Profile.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Profile.cs
@@ -60,7 +60,7 @@
         /// The User's role.
         /// </summary>
         [JsonProperty("role")]
-        public RoleResponse? Role { get; set; }
+        public RoleResponse Role { get; set; }
 
         /// <summary>
         /// The user's groups.

--- a/src/WorkOS.net/Services/_common/Entities/RoleResponse.cs
+++ b/src/WorkOS.net/Services/_common/Entities/RoleResponse.cs
@@ -1,0 +1,16 @@
+namespace WorkOS
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents a user's role.
+    /// </summary>
+    public class RoleResponse
+    {
+        /// <summary>
+        /// The slug identifier for the role.
+        /// </summary>
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+    }
+}

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -205,6 +205,7 @@
                 Email = "rick@sanchez.com",
                 FirstName = "Rick",
                 LastName = "Sanchez",
+                Role = new RoleResponse { Slug = "admin" },
                 Groups = new List<string>()
                 {
                     "Admins",
@@ -243,6 +244,8 @@
             Assert.Equal(
                 JsonConvert.SerializeObject(mockProfile),
                 JsonConvert.SerializeObject(profile));
+            Assert.NotNull(profile.Role);
+            Assert.Equal("admin", profile.Role.Slug);
         }
 
         [Fact]
@@ -258,6 +261,7 @@
                 Email = "rick@sanchez.com",
                 FirstName = "Rick",
                 LastName = "Sanchez",
+                Role = new RoleResponse { Slug = "admin" },
                 Groups = new List<string>()
                 {
                     "Admins",
@@ -287,6 +291,8 @@
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/sso/profile");
             this.httpMock.AssertAuthorizationBearerHeader("access_token");
+            Assert.NotNull(profile.Role);
+            Assert.Equal("admin", profile.Role.Slug);
         }
 
         [Fact]


### PR DESCRIPTION
## Description

Adds `role` to the profile object.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

[Docs PR](https://github.com/workos/workos/pull/31441)
