### PR TITLE
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Entities/DirectoryUser.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/DirectoryUser.cs
@@ -42,6 +42,10 @@
         /// <summary>
         /// The User's username.
         /// </summary>
+        [Obsolete(
+            "Will be removed in a future major version. Enable the `username` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.",
+            true
+        )]
         [JsonProperty("username")]
         public string Username { get; set; }
 
@@ -60,12 +64,26 @@
         /// <summary>
         /// The User's job title.
         /// </summary>
+        [Obsolete(
+            "Will be removed in a future major version. Enable the `job_title` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.",
+            true
+        )]
         [JsonProperty("job_title")]
         public string JobTitle { get; set; }
 
         /// <summary>
+        /// The primary email of the Directory User.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
         /// The User's e-mails.
         /// </summary>
+        [Obsolete(
+            "Will be removed in a future major version. Enable the `emails` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.",
+            true
+        )]
         [JsonProperty("emails")]
         public Email[] Emails { get; set; }
 
@@ -108,6 +126,7 @@
         /// <summary>
         /// The user's primary email.
         /// </summary>
+        [Obsolete("Use the `email` attribute instead.", true)]
         public Email PrimaryEmail
         {
             get { return this.Emails.First(email => email.Primary == true); }

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -71,6 +71,7 @@
                 OrganizationId = "org_123",
                 FirstName = "Rick",
                 LastName = "Sanchez",
+                Email = "rick.sanchez@foo-corp.com",
                 JobTitle = "Software Engineer",
                 Username = "rick.sanchez",
                 CreatedAt = "2021-07-26T18:55:16.072Z",


### PR DESCRIPTION
## Description
Add email standard attribute to DirectoryUser and mark deprecated standard attributes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
