### PR TITLE
Bump to v2.8.0

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "2.7.0";
+        public static string SdkVersion => "2.8.0";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>2.7.0</VersionPrefix>
-    <Version>2.7.0</Version>
+    <VersionPrefix>2.8.0</VersionPrefix>
+    <Version>2.8.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Bump to v2.8.0 for minor DirectoryUser addition.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
