### PR TITLE
Update PrimaryEmail implementation to allow for testing without obsolete fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ defaults:
 jobs:
   test:
     name: Test C# ${{ matrix.dotnet }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         dotnet: ["6.x", "7.x", "8.x"]
     steps:
+      # TODO: Remove libssl1.1 installation once we drop support for .NET Core 3.1
+      - name: Install libssl1.1 for .NET Core 3.1
+        run: |
+          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
       - uses: actions/checkout@v4
       - name: Setup dotNet
         uses: actions/setup-dotnet@v3

--- a/src/WorkOS.net/Services/DirectorySync/Entities/DirectoryUser.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/DirectoryUser.cs
@@ -121,7 +121,7 @@
         [Obsolete("Use the `email` attribute instead.", false)]
         public EmailObject PrimaryEmail
         {
-            get { return this.Emails.First(email => email.Primary == true); }
+            get { return this.Emails?.FirstOrDefault(email => email.Primary == true); }
         }
 
         /// <summary>

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -23,6 +23,8 @@
 
         private readonly DirectoryUser mockUser;
 
+        private readonly DirectoryUser mockUserWithoutEmails;
+
         private readonly Group mockGroup;
 
         public DirectorySyncServiceTest()
@@ -84,6 +86,44 @@
                         },
                     },
 #pragma warning restore 0618
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
+                State = DirectoryUserState.Active,
+                CustomAttributes = new Dictionary<string, object>()
+                {
+                    { "manager_id", "123" },
+                    { "job_title", "Software Engineer" },
+                    { "username", "rick.sanchez" },
+                    {
+                        "emails", new List<DirectoryUser.EmailObject>
+                        {
+                            new DirectoryUser.EmailObject
+                            {
+                                Primary = true,
+                                Value = "rick.sanchez@foo-corp.com",
+                                Type = "work",
+                            },
+                        }
+                    },
+                },
+                Groups = new List<DirectoryUser.Group>
+                {
+                    new DirectoryUser.Group
+                    {
+                        Id = "directory_group_123",
+                        Name = "Scientists",
+                    },
+                },
+            };
+
+            this.mockUserWithoutEmails = new DirectoryUser
+            {
+                Id = "directory_user_123",
+                DirectoryId = "dir_123",
+                OrganizationId = "org_123",
+                FirstName = "Rick",
+                LastName = "Sanchez",
+                Email = "rick.sanchez@foo-corp.com",
                 CreatedAt = "2021-07-26T18:55:16.072Z",
                 UpdatedAt = "2021-07-26T18:55:16.072Z",
                 State = DirectoryUserState.Active,
@@ -291,6 +331,26 @@
                 JsonConvert.SerializeObject(this.mockUser.Emails[0]),
 #pragma warning restore 0618
                 JsonConvert.SerializeObject(primaryEmail));
+        }
+
+        [Fact]
+        public async void TestPrimaryEmailNull()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Get,
+                $"/directory_users/{this.mockUserWithoutEmails.Id}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockUserWithoutEmails));
+
+            var user = await this.service.GetDirectoryUser(this.mockUserWithoutEmails.Id);
+#pragma warning disable 0618
+            var primaryEmail = user.PrimaryEmail;
+#pragma warning restore 0618
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Get,
+                $"/directory_users/{this.mockUserWithoutEmails.Id}");
+            Assert.Null(primaryEmail);
         }
     }
 }


### PR DESCRIPTION
## Description
Update PrimaryEmail implementation to allow for testing without obsolete fields.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
